### PR TITLE
State pub sub

### DIFF
--- a/eagle_mpc_2_control/CMakeLists.txt
+++ b/eagle_mpc_2_control/CMakeLists.txt
@@ -41,7 +41,7 @@ ament_target_dependencies(eagle_mpc_2_tools rclcpp px4_msgs px4_ros_com eagle_mp
 
 add_executable(decentralized_control ${DECENTRALIZED_CONTROL_SRC}) 
 ament_target_dependencies(decentralized_control rclcpp px4_msgs px4_ros_com eagle_mpc_2_msgs)
-# target_link_libraries(px4_controller ${MULTICOPTER_MPC_LIB})
+target_link_libraries(decentralized_control eagle_mpc_2_tools)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/eagle_mpc_2_control/CMakeLists.txt
+++ b/eagle_mpc_2_control/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(Eigen3 REQUIRED)
 find_package(px4_ros_com REQUIRED)
 find_package(eagle_mpc_2_msgs REQUIRED)
 
+set(EAGLE_MPC_2_TOOLS_SRC src/state_pub_sub.cpp)
 set(DECENTRALIZED_CONTROL_SRC src/decentralized_controller.cpp)
 
 # file(GLOB_RECURSE PX4_MPC_SOURCES *.cpp)
@@ -34,6 +35,9 @@ set(DECENTRALIZED_CONTROL_SRC src/decentralized_controller.cpp)
 # Setup targets #
 #################
 include_directories(include ${EIGEN3_INCLUDE_DIR})
+
+add_library(eagle_mpc_2_tools ${EAGLE_MPC_2_TOOLS_SRC})
+ament_target_dependencies(eagle_mpc_2_tools rclcpp px4_msgs px4_ros_com eagle_mpc_2_msgs)
 
 add_executable(decentralized_control ${DECENTRALIZED_CONTROL_SRC}) 
 ament_target_dependencies(decentralized_control rclcpp px4_msgs px4_ros_com eagle_mpc_2_msgs)

--- a/eagle_mpc_2_control/include/eagle_mpc_2_control/state_pub_sub.hpp
+++ b/eagle_mpc_2_control/include/eagle_mpc_2_control/state_pub_sub.hpp
@@ -1,0 +1,65 @@
+#ifndef EAGLE_MPC_2_CONTROL_STATE_PUB_SUB_HPP
+#define EAGLE_MPC_2_CONTROL_STATE_PUB_SUB_HPP
+
+#include <chrono>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <Eigen/Dense>
+
+#include <px4_msgs/msg/timesync.hpp>
+#include <px4_msgs/msg/vehicle_local_position.hpp>
+#include <px4_msgs/msg/vehicle_attitude.hpp>
+#include <px4_msgs/msg/vehicle_angular_velocity.hpp>
+
+#include <px4_ros_com/frame_transforms.h>
+
+#include "eagle_mpc_2_msgs/msg/platform_state.hpp"
+
+// Transformation tools
+const Eigen::Quaterniond FRD_FLU_Q =
+    px4_ros_com::frame_transforms::utils::quaternion::quaternion_from_euler(M_PI, 0.0, 0.0);
+const Eigen::Quaterniond NWU_NED_Q =
+    px4_ros_com::frame_transforms::utils::quaternion::quaternion_from_euler(M_PI, 0.0, 0.0);
+
+class StatePubSub {
+ public:
+  explicit StatePubSub(rclcpp::Node::SharedPtr node, const bool& sub = true, const bool& pub = true);
+  virtual ~StatePubSub();
+
+ protected:
+  rclcpp::Node::SharedPtr node_;
+
+  std::atomic<uint64_t> timestamp_;  //!< common synced timestamped
+
+  // pubs
+  rclcpp::Publisher<eagle_mpc_2_msgs::msg::PlatformState>::SharedPtr platform_state_publisher_;
+
+  // subs
+  rclcpp::Subscription<px4_msgs::msg::Timesync>::SharedPtr timesync_sub_;
+  rclcpp::Subscription<px4_msgs::msg::VehicleLocalPosition>::SharedPtr local_position_subs_;
+  rclcpp::Subscription<px4_msgs::msg::VehicleAttitude>::SharedPtr attitude_subs_;
+  rclcpp::Subscription<px4_msgs::msg::VehicleAngularVelocity>::SharedPtr angular_velocity_subs_;
+
+  // Class variables
+  Eigen::VectorXd state_;  // local pos in inertial frame (NWU), quaternion (x,y,z,w. From FLU to NWU), lin. velocity
+                           // and ang. velocity (FLU base frame)
+  Eigen::Vector3d vel_ned_;
+  Eigen::Vector3d vel_frd_;
+  Eigen::Quaterniond q_ned_frd_;
+  Eigen::Quaterniond q_nwu_flu_;
+
+  // State subscribers callbacks
+  void timeSyncCallback(const px4_msgs::msg::Timesync::UniquePtr msg);
+  void vehicleLocalPositionCallback(const px4_msgs::msg::VehicleLocalPosition::UniquePtr msg);
+  void vehicleAttitudeCallback(const px4_msgs::msg::VehicleAttitude::UniquePtr msg);
+  void vehicleAngularVelocityCallback(const px4_msgs::msg::VehicleAngularVelocity::UniquePtr msg);
+
+  // methods
+  void publish_platform_state();
+
+  // msgs
+  eagle_mpc_2_msgs::msg::PlatformState platform_state_msg_;
+};
+#endif

--- a/eagle_mpc_2_control/include/eagle_mpc_2_control/state_pub_sub.hpp
+++ b/eagle_mpc_2_control/include/eagle_mpc_2_control/state_pub_sub.hpp
@@ -25,22 +25,13 @@ const Eigen::Quaterniond NWU_NED_Q =
 
 class StatePubSub {
  public:
-  explicit StatePubSub(rclcpp::Node::SharedPtr node, const bool& sub = true, const bool& pub = true);
+  explicit StatePubSub(rclcpp::Node::SharedPtr node, const bool& pub = true);
   virtual ~StatePubSub();
 
  protected:
   rclcpp::Node::SharedPtr node_;
 
   std::atomic<uint64_t> timestamp_;  //!< common synced timestamped
-
-  // pubs
-  rclcpp::Publisher<eagle_mpc_2_msgs::msg::PlatformState>::SharedPtr platform_state_publisher_;
-
-  // subs
-  rclcpp::Subscription<px4_msgs::msg::Timesync>::SharedPtr timesync_sub_;
-  rclcpp::Subscription<px4_msgs::msg::VehicleLocalPosition>::SharedPtr local_position_subs_;
-  rclcpp::Subscription<px4_msgs::msg::VehicleAttitude>::SharedPtr attitude_subs_;
-  rclcpp::Subscription<px4_msgs::msg::VehicleAngularVelocity>::SharedPtr angular_velocity_subs_;
 
   // Class variables
   Eigen::VectorXd state_;  // local pos in inertial frame (NWU), quaternion (x,y,z,w. From FLU to NWU), lin. velocity
@@ -49,6 +40,16 @@ class StatePubSub {
   Eigen::Vector3d vel_frd_;
   Eigen::Quaterniond q_ned_frd_;
   Eigen::Quaterniond q_nwu_flu_;
+
+ private:
+  // pubs
+  rclcpp::Publisher<eagle_mpc_2_msgs::msg::PlatformState>::SharedPtr platform_state_publisher_;
+
+  // subs
+  rclcpp::Subscription<px4_msgs::msg::Timesync>::SharedPtr timesync_sub_;
+  rclcpp::Subscription<px4_msgs::msg::VehicleLocalPosition>::SharedPtr local_position_subs_;
+  rclcpp::Subscription<px4_msgs::msg::VehicleAttitude>::SharedPtr attitude_subs_;
+  rclcpp::Subscription<px4_msgs::msg::VehicleAngularVelocity>::SharedPtr angular_velocity_subs_;
 
   // State subscribers callbacks
   void timeSyncCallback(const px4_msgs::msg::Timesync::UniquePtr msg);
@@ -61,5 +62,7 @@ class StatePubSub {
 
   // msgs
   eagle_mpc_2_msgs::msg::PlatformState platform_state_msg_;
+
+  bool pub_enabled_;
 };
 #endif

--- a/eagle_mpc_2_control/src/decentralized_controller.cpp
+++ b/eagle_mpc_2_control/src/decentralized_controller.cpp
@@ -2,26 +2,13 @@
 
 using namespace std::chrono_literals;
 
-DecentralizedController::DecentralizedController(rclcpp::Node::SharedPtr node) : node_(node) {
+DecentralizedController::DecentralizedController(rclcpp::Node::SharedPtr node) : StatePubSub(node) {
   offboard_control_mode_publisher_ =
       node_->create_publisher<px4_msgs::msg::OffboardControlMode>("OffboardControlMode_PubSubTopic", 10);
   trajectory_setpoint_publisher_ =
       node_->create_publisher<px4_msgs::msg::TrajectorySetpoint>("TrajectorySetpoint_PubSubTopic", 10);
   vehicle_command_publisher_ =
       node_->create_publisher<px4_msgs::msg::VehicleCommand>("VehicleCommand_PubSubTopic", 10);
-  platform_state_publisher_ = node_->create_publisher<eagle_mpc_2_msgs::msg::PlatformState>("PlatformState", 10);
-
-  timesync_sub_ = node_->create_subscription<px4_msgs::msg::Timesync>(
-      "Timesync_PubSubTopic", 10, std::bind(&DecentralizedController::timeSyncCallback, this, std::placeholders::_1));
-  local_position_subs_ = node_->create_subscription<px4_msgs::msg::VehicleLocalPosition>(
-      "VehicleLocalPosition_PubSubTopic", 10,
-      std::bind(&DecentralizedController::vehicleLocalPositionCallback, this, std::placeholders::_1));
-  attitude_subs_ = node_->create_subscription<px4_msgs::msg::VehicleAttitude>(
-      "VehicleAttitude_PubSubTopic", 10,
-      std::bind(&DecentralizedController::vehicleAttitudeCallback, this, std::placeholders::_1));
-  angular_velocity_subs_ = node_->create_subscription<px4_msgs::msg::VehicleAngularVelocity>(
-      "VehicleAngularVelocity_PubSubTopic", 10,
-      std::bind(&DecentralizedController::vehicleAngularVelocityCallback, this, std::placeholders::_1));
 
   offboard_setpoint_counter_ = 0;
   timer_ = node_->create_wall_timer(100ms, std::bind(&DecentralizedController::timerCallback, this));
@@ -60,10 +47,6 @@ DecentralizedController::DecentralizedController(rclcpp::Node::SharedPtr node) :
 }
 
 DecentralizedController::~DecentralizedController() {}
-
-void DecentralizedController::timeSyncCallback(const px4_msgs::msg::Timesync::UniquePtr msg) {
-  timestamp_.store(msg->timestamp);
-}
 
 void DecentralizedController::timerCallback() {
   if (offboard_setpoint_counter_ == 10) {
@@ -137,62 +120,6 @@ void DecentralizedController::publish_vehicle_command(uint16_t command, float pa
   msg.from_external = true;
 
   vehicle_command_publisher_->publish(msg);
-}
-
-void DecentralizedController::vehicleLocalPositionCallback(const px4_msgs::msg::VehicleLocalPosition::UniquePtr msg) {
-  // We use the local inertial frame: NWU
-  // Position in the inertial frame
-  state_(0) = msg->x;
-  state_(1) = -msg->y;
-  state_(2) = -msg->z;
-
-  // Velocity in the body frame (FLU)
-  vel_ned_(0) = msg->vx;
-  vel_ned_(1) = msg->vy;
-  vel_ned_(2) = msg->vz;
-  vel_frd_ = px4_ros_com::frame_transforms::transform_frame(vel_ned_, q_ned_frd_.conjugate());
-  state_(7) = vel_frd_(0);
-  state_(8) = -vel_frd_(1);
-  state_(9) = -vel_frd_(2);
-}
-
-void DecentralizedController::vehicleAttitudeCallback(const px4_msgs::msg::VehicleAttitude::UniquePtr msg) {
-  q_ned_frd_ = px4_ros_com::frame_transforms::utils::quaternion::array_to_eigen_quat(msg->q);
-  q_nwu_flu_ = NWU_NED_Q * q_ned_frd_ * FRD_FLU_Q;
-  state_(3) = q_nwu_flu_.x();
-  state_(4) = q_nwu_flu_.y();
-  state_(5) = q_nwu_flu_.z();
-  state_(6) = q_nwu_flu_.w();
-}
-
-void DecentralizedController::vehicleAngularVelocityCallback(const px4_msgs::msg::VehicleAngularVelocity::UniquePtr msg) {
-  state_(10) = msg->xyz[0];
-  state_(11) = -msg->xyz[1];
-  state_(12) = -msg->xyz[2];
-
-  publish_platform_state();
-}
-
-void DecentralizedController::publish_platform_state() {
-  // platform_state_msg_.header.frame_id = 0
-  platform_state_msg_.header.stamp = node_->now();
-
-  platform_state_msg_.pose.position.x = state_(0);
-  platform_state_msg_.pose.position.y = state_(1);
-  platform_state_msg_.pose.position.z = state_(2);
-  platform_state_msg_.pose.orientation.x = state_(3);
-  platform_state_msg_.pose.orientation.y = state_(4);
-  platform_state_msg_.pose.orientation.z = state_(5);
-  platform_state_msg_.pose.orientation.w = state_(6);
-
-  platform_state_msg_.motion.linear.x = state_(7);
-  platform_state_msg_.motion.linear.y = state_(8);
-  platform_state_msg_.motion.linear.z = state_(9);
-  platform_state_msg_.motion.angular.x = state_(10);
-  platform_state_msg_.motion.angular.y = state_(11);
-  platform_state_msg_.motion.angular.z = state_(12);
-
-  platform_state_publisher_->publish(platform_state_msg_);
 }
 
 int main(int argc, char *argv[]) {

--- a/eagle_mpc_2_control/src/state_pub_sub.cpp
+++ b/eagle_mpc_2_control/src/state_pub_sub.cpp
@@ -1,0 +1,88 @@
+#include "eagle_mpc_2_control/state_pub_sub.hpp"
+
+using namespace std::chrono_literals;
+
+StatePubSub::StatePubSub(rclcpp::Node::SharedPtr node, const bool& sub, const bool& pub) : node_(node) {
+  if (!sub && !pub) {
+    // throw error if both are false
+  }
+
+  platform_state_publisher_ = node_->create_publisher<eagle_mpc_2_msgs::msg::PlatformState>("PlatformState", 10);
+
+  timesync_sub_ = node_->create_subscription<px4_msgs::msg::Timesync>(
+      "Timesync_PubSubTopic", 10, std::bind(&StatePubSub::timeSyncCallback, this, std::placeholders::_1));
+  local_position_subs_ = node_->create_subscription<px4_msgs::msg::VehicleLocalPosition>(
+      "VehicleLocalPosition_PubSubTopic", 10,
+      std::bind(&StatePubSub::vehicleLocalPositionCallback, this, std::placeholders::_1));
+  attitude_subs_ = node_->create_subscription<px4_msgs::msg::VehicleAttitude>(
+      "VehicleAttitude_PubSubTopic", 10,
+      std::bind(&StatePubSub::vehicleAttitudeCallback, this, std::placeholders::_1));
+  angular_velocity_subs_ = node_->create_subscription<px4_msgs::msg::VehicleAngularVelocity>(
+      "VehicleAngularVelocity_PubSubTopic", 10,
+      std::bind(&StatePubSub::vehicleAngularVelocityCallback, this, std::placeholders::_1));
+
+  // State variable init
+  state_ = Eigen::VectorXd::Zero(13);
+}
+
+StatePubSub::~StatePubSub() {}
+
+void StatePubSub::timeSyncCallback(const px4_msgs::msg::Timesync::UniquePtr msg) {
+  timestamp_.store(msg->timestamp);
+}
+
+void StatePubSub::vehicleLocalPositionCallback(const px4_msgs::msg::VehicleLocalPosition::UniquePtr msg) {
+  // We use the local inertial frame: NWU
+  // Position in the inertial frame
+  state_(0) = msg->x;
+  state_(1) = -msg->y;
+  state_(2) = -msg->z;
+
+  // Velocity in the body frame (FLU)
+  vel_ned_(0) = msg->vx;
+  vel_ned_(1) = msg->vy;
+  vel_ned_(2) = msg->vz;
+  vel_frd_ = px4_ros_com::frame_transforms::transform_frame(vel_ned_, q_ned_frd_.conjugate());
+  state_(7) = vel_frd_(0);
+  state_(8) = -vel_frd_(1);
+  state_(9) = -vel_frd_(2);
+}
+
+void StatePubSub::vehicleAttitudeCallback(const px4_msgs::msg::VehicleAttitude::UniquePtr msg) {
+  q_ned_frd_ = px4_ros_com::frame_transforms::utils::quaternion::array_to_eigen_quat(msg->q);
+  q_nwu_flu_ = NWU_NED_Q * q_ned_frd_ * FRD_FLU_Q;
+  state_(3) = q_nwu_flu_.x();
+  state_(4) = q_nwu_flu_.y();
+  state_(5) = q_nwu_flu_.z();
+  state_(6) = q_nwu_flu_.w();
+}
+
+void StatePubSub::vehicleAngularVelocityCallback(const px4_msgs::msg::VehicleAngularVelocity::UniquePtr msg) {
+  state_(10) = msg->xyz[0];
+  state_(11) = -msg->xyz[1];
+  state_(12) = -msg->xyz[2];
+
+  publish_platform_state();
+}
+
+void StatePubSub::publish_platform_state() {
+  // platform_state_msg_.header.frame_id = 0
+  platform_state_msg_.header.stamp = node_->now();
+
+  platform_state_msg_.pose.position.x = state_(0);
+  platform_state_msg_.pose.position.y = state_(1);
+  platform_state_msg_.pose.position.z = state_(2);
+  platform_state_msg_.pose.orientation.x = state_(3);
+  platform_state_msg_.pose.orientation.y = state_(4);
+  platform_state_msg_.pose.orientation.z = state_(5);
+  platform_state_msg_.pose.orientation.w = state_(6);
+
+  platform_state_msg_.motion.linear.x = state_(7);
+  platform_state_msg_.motion.linear.y = state_(8);
+  platform_state_msg_.motion.linear.z = state_(9);
+  platform_state_msg_.motion.angular.x = state_(10);
+  platform_state_msg_.motion.angular.y = state_(11);
+  platform_state_msg_.motion.angular.z = state_(12);
+
+  platform_state_publisher_->publish(platform_state_msg_);
+}


### PR DESCRIPTION
This PR adds a class that handles the construction of the state in the EagleMPC convention. It subscribes to PX4 topics and, doing the necessary transformation, it stores the state in an internal class variable.

Other controllers requiring this functionality (as the Decentralized Controller) may derive from this class. Optionally, there is a publisher to publish the internal state in a topic.